### PR TITLE
feat: cache results on redis ✨

### DIFF
--- a/licenseware/common/constants/envs.py
+++ b/licenseware/common/constants/envs.py
@@ -85,6 +85,14 @@ class envs:
     MONGO_COLLECTION_FEATURES_NAME:str = COLLECTION_PREFIX + "Features"
     
         
+    # Redis connection
+    REDIS_HOST: str = os.getenv("REDIS_HOST", "localhost")
+    REDIS_PORT: int = int(os.getenv("REDIS_PORT", "6379"))
+    REDIS_DB: int = int(os.getenv("REDIS_DB", "0"))
+    REDIS_PASSWORD: str = os.getenv("REDIS_PASSWORD", "")
+
+    REDIS_REQUEST_CACHE_DB: int = int(os.getenv("REDIS_REQUEST_CACHE_DB", "15"))
+
     # Environment variables added later by the app
     # envs.method_name() - calls the variable dynamically 
     # you can access class vars with cls.attr_name ex: cls.MONGO_COLLECTION_DATA_NAME

--- a/licenseware/common/constants/envs.py
+++ b/licenseware/common/constants/envs.py
@@ -91,7 +91,7 @@ class envs:
     REDIS_DB: int = int(os.getenv("REDIS_DB", "0"))
     REDIS_PASSWORD: str = os.getenv("REDIS_PASSWORD", "")
 
-    REDIS_REQUEST_CACHE_DB: int = int(os.getenv("REDIS_REQUEST_CACHE_DB", "15"))
+    REDIS_RESULT_CACHE_DB: int = int(os.getenv("REDIS_RESULT_CACHE_DB", "15"))
 
     # Environment variables added later by the app
     # envs.method_name() - calls the variable dynamically 

--- a/licenseware/decorators/caching.py
+++ b/licenseware/decorators/caching.py
@@ -1,0 +1,55 @@
+import pickle
+from functools import wraps
+from typing import Callable
+
+from licenseware.dependencies.redis_cache import RedisCache
+
+caching_database = RedisCache()
+TEN_MINUTES = 600
+
+
+def _serialize(obj):
+    return pickle.dumps(obj)
+
+
+def _deserialize(obj):
+    return pickle.loads(obj)
+
+
+def _hash_args(*args, **kwargs):
+    return _serialize((args, kwargs))
+
+
+def _lookup_value(key):
+    value = caching_database.get(key)
+    if value:
+        return _deserialize(value)
+
+
+def _save_result(key, result, expiry):
+    return caching_database.set(key, _serialize(result), expiry)
+
+
+def cache_result(fn: Callable = None, expiry: int = TEN_MINUTES) -> Callable:
+    """
+    Decorator to cache the result of a flask request.
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        @wraps(fn)
+        def wrapper(*args, **kwargs) -> Callable:
+            hashed_request = _hash_args(*args, **kwargs)
+            cached_result = _lookup_value(hashed_request)
+
+            if cached_result:
+                return cached_result
+
+            result = fn(*args, **kwargs)
+
+            _save_result(hashed_request, result, expiry)
+
+            return result
+
+        return wrapper
+
+    return decorator(fn) if fn else decorator

--- a/licenseware/dependencies/redis_cache.py
+++ b/licenseware/dependencies/redis_cache.py
@@ -11,8 +11,8 @@ class RedisCache:
         self.redis = Redis(
             host=host or envs.REDIS_HOST,
             port=port or envs.REDIS_PORT,
-            db=db or envs.REDIS_REQUEST_CACHE_DB,
-            password=envs.REDIS_PASSWORD,
+            db=db or envs.REDIS_RESULT_CACHE_DB,
+            password=password or envs.REDIS_PASSWORD,
         )
 
     def get(self, key: str) -> str:

--- a/licenseware/dependencies/redis_cache.py
+++ b/licenseware/dependencies/redis_cache.py
@@ -1,0 +1,23 @@
+from datetime import timedelta
+
+from licenseware.common.constants import envs
+from redis import Redis
+
+
+class RedisCache:
+    def __init__(
+        self, host: str = None, port: int = None, db: int = None, password: str = None
+    ):
+        self.redis = Redis(
+            host=host or envs.REDIS_HOST,
+            port=port or envs.REDIS_PORT,
+            db=db or envs.REDIS_REQUEST_CACHE_DB,
+            password=envs.REDIS_PASSWORD,
+        )
+
+    def get(self, key: str) -> str:
+        return self.redis.get(key)
+
+    def set(self, key: str, value: bytes, expiry: int) -> bool:
+        assert isinstance(value, bytes), "value must be bytes"
+        return self.redis.set(key, value, ex=timedelta(seconds=expiry))


### PR DESCRIPTION
@ciprian-cgr 
@ClimenteA 
@adrian-mih 

It can be applied to any function on anywhere:

## Example 1 

```python
from licenseware.decorators.caching import cache_result

@cache_result(expiry=300)  # five minutes (default is ten)
def get_data(self, flask_request):
    ...
    # some process
    return result
```

## Example 2

```python
from licenseware.decorators.caching import cache_result

def get_data(self, flask_request):
    ...
    # some process
    result = self._io_access(pipeline, collection=DATA_COLLECTION)
    return result

@cache_result(expiry=900)  # fifteen minutes
def _io_access(self, *args, **kwargs):
    return mongodata.fetch(*args, **kwargs) 
```
