### PR TITLE
fix: change default log level to info 🔊

### DIFF
--- a/licenseware/utils/logger.py
+++ b/licenseware/utils/logger.py
@@ -67,8 +67,8 @@ except Exception:
     print("Outside flask context")
     outside_flask = True
 
-_debug = os.getenv("DEBUG", "").lower() == "true"
-_log_level = "DEBUG" if _debug else "WARNING"
+_debug = bool(os.getenv("DEBUG", ""))
+_log_level = os.getenv("LOG_LEVEL", "INFO").upper() if not _debug else "DEBUG"
 
 if "local" in os.getenv("ENVIRONMENT", "local").lower():
     _log_format = """<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green>[ <level>{level}</level> ]


### PR DESCRIPTION
LW-2074

@adrian-mih This will fix your problem about `log.info` not showing up. Bump a new SDK release and update your base image to see the logs.