### PR TITLE
chore: remove watchdog from production requirement ✨

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aioredis==1.3.1
 Babel==2.9.1
 cachetools==5.0.0
 dnspython==2.1.0
-dramatiq[watch]==1.11.0
+dramatiq==1.11.0
 Flask==2.0.3
 Flask-Cors==3.0.10
 flask-restx==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ EXTRAS = {
     "trend-app": [
         "trend-app-protect==4.6.2",
     ],
+    "watchdog": [
+        "dramatiq[watch]",
+    ],
 }
 
 setup(


### PR DESCRIPTION
LW-2007

@adrian-mih
@ClimenteA 

Again, if you need anything from the SDK that **is related to your dev environment**, simply run any of the following:

```bash
pip install licenseware[watchdog]
# or
pip install -e /path/to/sdk/[watchdog]
```